### PR TITLE
Add support for showing past events

### DIFF
--- a/static/wautils.js
+++ b/static/wautils.js
@@ -179,6 +179,18 @@ $(document).on('click', '#nav_logout',function()  {
 
 })
 */
+$(document).on('click','#event_filter_past', () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  urlParams.set('filter', 'IsUpcoming eq False');
+  window.location.search = urlParams;
+})
+
+$(document).on('click','#event_filter_upcoming', () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  urlParams.delete('filter');
+  window.location.search = urlParams;
+})
+
 
 function extract_contentfield(j,fieldname) {
   // called from the get 
@@ -1160,11 +1172,17 @@ function signoffs_save() {
   })
 }
 
+function get_event_filter() {
+  var searchParams = new URLSearchParams(window.location.search);
+  return searchParams.get('filter') || "IsUpcoming eq True";
+}
+
 function get_events() {
+
   // get contacts list
   // https://app.swaggerhub.com/apis-docs/WildApricot/wild-apricot_public_api/2.1.0#/Contacts/GetContactsList
   fep  = $.param({
-    '$filter':'IsUpcoming eq True',
+    '$filter': get_event_filter(),
     '$sort':'ByStartDate asc'
   } )
   ep = $.param( {'endpoint':'accounts/$accountid/events/?' + fep})
@@ -1441,7 +1459,13 @@ function process_events(j) {
   } else  {
 
     o = ''
-    o += '<h3>Upcoming Events</h3>'
+    o += '<h3>'
+    o += '<span>Events</span>'
+    o += '<div class="float-right btn-group" role="group">'
+    o += '  <button type="button" class="btn btn-light" id="event_filter_past">Past Events</button>'
+    o += '  <button type="button" class="btn btn-light" id="event_filter_upcoming">Upcoming Events</button>'
+    o += '</div>'
+    o += '</h3>'
 
     o += '<table id="events_table"></table>'
 


### PR DESCRIPTION
The user can now choose to see "Past Events" and "Upcoming Events" via a couple of buttons above the events table.

![Preview](https://user-images.githubusercontent.com/16963/113936518-dc947380-97c5-11eb-8c9e-c01d824d587b.gif)

Being able to find past events is very helpful when filling in the event reimbursement forms and the instructor needs to lookup attendee emails.

This exposes the filter as a query parameter in the events page. That param is extracted by the `get_events` function when making the request to WA.

I implemented it this way for a couple of reasons:

1. It centralizes the API request params in one place: the query params.
2. Query params make since here since we are adding parameters to a query.
3. I didn't have to change or add any new code paths for loading the list of events on the page.
