### PR TITLE
Add the Event Id to the Event Registrations Page

### DIFF
--- a/static/events-page.js
+++ b/static/events-page.js
@@ -122,7 +122,7 @@ $(document).ready(() => {
         o += '<h3>Event Registrations</h3>';
         o += `<h2>${event_info[0].Event.Name}</h2>`;
         o += `<p>Event ID: <code>${gl_event_id}</code></p>`;
-        o += '<button class="btn btn-info    btn-inline btn-sm m-1" id="show_events_btn">BACK</button>';
+        o += '<button class="btn btn-info btn-inline btn-sm m-1 d-print-none" id="show_events_btn">BACK</button>';
         o += '<table id="events_table" class="table table-striped"></table>';
         $('#maindiv').html(o);
 
@@ -248,7 +248,7 @@ $(document).ready(() => {
     o = '';
     o += '<h3>';
     o += '<span>Events</span>';
-    o += '<div class="float-right btn-group" role="group">';
+    o += '<div class="float-right btn-group d-print-none" role="group">';
     o += '  <button type="button" class="btn btn-light" id="event_filter_past">Past Events</button>';
     o += '  <button type="button" class="btn btn-light" id="event_filter_upcoming">Upcoming Events</button>';
     o += '</div>';

--- a/static/events-page.js
+++ b/static/events-page.js
@@ -121,6 +121,7 @@ $(document).ready(() => {
         o = '';
         o += '<h3>Event Registrations</h3>';
         o += `<h2>${event_info[0].Event.Name}</h2>`;
+        o += `<p>Event ID: <code>${gl_event_id}</code></p>`;
         o += '<button class="btn btn-info    btn-inline btn-sm m-1" id="show_events_btn">BACK</button>';
         o += '<table id="events_table" class="table table-striped"></table>';
         $('#maindiv').html(o);

--- a/static/wautils.css
+++ b/static/wautils.css
@@ -68,3 +68,10 @@ main {
 .badge-nlgroup {
   background-color:  #28a745;
 }
+
+@media print {
+  .fixed-table-toolbar
+  {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
Add the Event Id to the Event Registrations Page. And clean up the print display a little bit.

This was a [feature request](https://nova-labs-org.slack.com/archives/C0K311J3B/p1620393720404200) on slack in the #support-it channel:

> Could you make the Event Id show up on this screen please. I was looking at the workflow for the Formbot and the new instructions. Someone promised to do an OBS for me, but ... Anyway, when they print or save their class roster for use to take attendance, it would be good if the event ID was on the paper so they could have it to enter it into the Formbot without having to look it up again. I think that might help make things a wee bit smoother for them.

----

![CleanShot 2021-05-07 at 10 19 28@2x](https://user-images.githubusercontent.com/16963/117463523-c5a88480-af1d-11eb-9cc9-902c56a05043.png)
_Check out that sweet "Event ID" under the title._ 

----

![CleanShot 2021-05-07 at 10 18 21@2x](https://user-images.githubusercontent.com/16963/117463459-b1648780-af1d-11eb-9347-d6d87c37a2e2.png)
_Even shows up on the print display. Along with a handy table of class attendees._ 
