### PR TITLE
Add confirmation to the Signoff by Tool form

### DIFF
--- a/static/tool-signoffs-page.js
+++ b/static/tool-signoffs-page.js
@@ -175,20 +175,23 @@ $(document).ready(() => {
   $(document).on('submit', 'form', function (e) {
     e.preventDefault();
 
-    ids = read_form_contact_ids();
-    promises = ids.map(function(id) {
-      const data = munge_form_with_contact(id);
-      return WAAPI.update_contact(data.Id, data, function(json) {
-        return json;
+    const count = $('input[name^="contact[]"]').length;
+    if (confirm(`Are you really, really sure you want to grant ${count} member(s) this signoff?`)) {
+      ids = read_form_contact_ids();
+      promises = ids.map(function(id) {
+        const data = munge_form_with_contact(id);
+        return WAAPI.update_contact(data.Id, data, function(json) {
+          return json;
+        });
       });
-    });
 
-    Promise.all(promises).then(function(results) {
-      render_success_alert(results);
-      reset_form();
-    }).catch(function(error) {
-      alert("Error Updating Contacts");
-    });
+      Promise.all(promises).then(function(results) {
+        render_success_alert(results);
+        reset_form();
+      }).catch(function(error) {
+        alert("Error Updating Contacts");
+      });
+    }
   });
 
   //


### PR DESCRIPTION
@sudobob wanted to confirm the form before submitting. I assume it is because he just clicks random buttons on webpages without thinking.

<img width="1108" alt="image" src="https://user-images.githubusercontent.com/16963/119360958-24d5fb00-bc79-11eb-94c9-37deab713671.png">
