### PR TITLE
Show GO status on Batch Update

### DIFF
--- a/static/tool-signoffs-page.js
+++ b/static/tool-signoffs-page.js
@@ -30,6 +30,18 @@ $(document).ready(() => {
     });
   }
 
+  function has_go(contact) {
+    const signoffs = contact.FieldValues.find(function(v) {
+      return v.FieldName == "NL Signoffs and Categories";
+    });
+
+    const go_signoff = signoffs.Value.find(function (v) {
+      return v.Label ==  "[nlgroup] GO_New Member Orientation";
+    });
+
+    return (typeof go_signoff !== 'undefined')
+  }
+
   function set_signoff_field_system_code(code){
     $('#signoff_field_system_code').val(code);
   }
@@ -161,6 +173,7 @@ $(document).ready(() => {
   $(document).on('click', ".contact-to-add", function() {
     var tpl = $("#contact_fields_mustache").html();
     var vars = get_contact(this.getAttribute("value"));
+    vars.has_go = has_go(vars);
     $('#contact_field_list').append(Mustache.render(tpl, vars));
     $('#contact_search').prop('required', false);
     reset_contact_search();

--- a/templates/tool_signoffs.html
+++ b/templates/tool_signoffs.html
@@ -94,6 +94,12 @@
                     <span class="float-right">
                       <a href="#" class="remove-contact text-danger ">remove</a>
                     </span>
+                    <br>
+                    {{^has_go}}
+                      <small>
+                        <span class="badge badge-warning">WARNING</span> This person does has not completed Green Orientation
+                      </small>
+                    {{/has_go}}
                   </li>
                 </script>
                 {% endraw %}


### PR DESCRIPTION
Add visual feedback on the Batch Sign-off page (e.g. the add sign-offs by tool page). This does not enforce any validation logic, just presents more data.

When adding a user to a tool sign-off if they don't have GO yet, we will show a warning.

![CleanShot 2021-06-14 at 13 53 14@2x](https://user-images.githubusercontent.com/16963/121937454-b1c02180-cd18-11eb-8335-b564f0f26af1.png)
