### PR TITLE
Fetch user details after saving

### DIFF
--- a/static/tool-signoffs-page.js
+++ b/static/tool-signoffs-page.js
@@ -187,7 +187,9 @@ $(document).ready(() => {
 
       Promise.all(promises).then(function(results) {
         render_success_alert(results);
-        reset_form();
+        get_contacts().then(function(resolve, reject) {
+          reset_form();
+        });
       }).catch(function(error) {
         alert("Error Updating Contacts");
       });


### PR DESCRIPTION
The user (contact in WA parlance) attributes are being stored in memory on the page, when we update a contact by adding a sign-off the user data becomes stale. This can cause a bug where subsequent submissions will clobber previous updates with the stale data.

In other words, when adding multiple sign-offs only the last one will stick. Sneaky lil bug 🐞 

This is the brute force approach where the page re-fetches all the contacts in the system after each submission. This way we are not syncing, munging, or reconciling any changes to the data in the browser. Only one way to get an update: ask Wild Apricot and process it the same way.

Damn, we need a model layer for this logic. One day.