### PR TITLE
Link directly to FormBot from Event Details

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -5,4 +5,4 @@ OAUTH_ID='xxxxxx'
 OAUTH_API_KEY='------------------------------'
 OAUTH_SECRET='-----------------------------'
 OAUTH_AUTHORIZE_URL='https://xxx.wildapricot.org/sys/login/OAuthLogin'
-
+FORMBOT_URL='https://forestfire.net:8020?'

--- a/static/events-page.js
+++ b/static/events-page.js
@@ -122,7 +122,14 @@ $(document).ready(() => {
         o += '<h3>Event Registrations</h3>';
         o += `<h2>${event_info[0].Event.Name}</h2>`;
         o += `<p>Event ID: <code>${gl_event_id}</code></p>`;
-        o += '<button class="btn btn-info btn-inline btn-sm m-1 d-print-none" id="show_events_btn">BACK</button>';
+
+        o += '<p class="d-print-none">';
+        o += '<button class="btn btn-info btn-inline btn-sm mr-1" id="show_events_btn">Back</button>';
+        if (window.formbot_url) {
+          o += `<a href="${window.formbot_url}${gl_event_id}" class="btn btn-warning btn-sm">Instructor Formbot</a>`;
+        }
+        o += '</p>';
+
         o += '<table id="events_table" class="table table-striped"></table>';
         $('#maindiv').html(o);
 

--- a/static/wautils.css
+++ b/static/wautils.css
@@ -15,10 +15,8 @@ handy for analysis
 }
 
 .btn {
-  display: block;
   padding: .25rem;
 }
-
 
 p.bigger {
   font-size: 1.2rem;

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,7 @@ bootstrap friendly manner #}
     window.wa_me={{ g.wa_me | tojson }};
     window.wa_admin={{ g.is_wa_admin | tojson }};
     window.wa_signoffer={{ g.is_wa_signoffer | tojson }};
+    window.formbot_url="{{ g.formbot_url }}";
     {% endif %}
   </script>
 {% endblock %}

--- a/wautils.py
+++ b/wautils.py
@@ -155,6 +155,7 @@ def before_authenticated_request():
     g.is_wa_admin = is_account_admin(waco)
     g.is_wa_signoffer = has_wautils_signoff(waco)
     g.wa_url = os.getenv('WA_SITE_URL')
+    g.formbot_url = os.getenv('FORMBOT_URL')
 
 @app.errorhandler(401)
 def unauthorized_handler(error):


### PR DESCRIPTION
Thanks to the amazing @Pecacheu and the change in [FormBot][1] we can now link directly to an Instructor Payment & Maker Sign-off page and have the event prepopulated. Hopefully this will simplify the process and reduce confusion and work.

![CleanShot 2021-06-17 at 17 06 24@2x](https://user-images.githubusercontent.com/16963/122473520-f86b8100-cf8f-11eb-820b-7ff0bfb67356.png)


Adds a setting that must be configured in the environment variables for the base URL. That URL is concatenated with the event ID and a button is shown in the events page detail view. If the setting does not exist the button is not rendered.

DEPLOYMENT NOTE: Don't forget to add the FORMBOT_URL setting to the env when deploying to production.

[1]: https://github.com/Pecacheu/NovaLabs-Instructor-Form/commit/5ac67c9f6ed478011d878bc4af1e64a8e0958201